### PR TITLE
Resize uploaded images to 300x300 pixels before saving to the database

### DIFF
--- a/app/Filament/Resources/GalleryResource.php
+++ b/app/Filament/Resources/GalleryResource.php
@@ -26,6 +26,8 @@ use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+
 
 class GalleryResource extends Resource
 {
@@ -50,7 +52,7 @@ class GalleryResource extends Resource
             ->schema([
                 Section::make('Gallery Information')->schema([
                     TextInput::make('name')->label('Name')->columnSpanFull()->required(),
-                    FileUpload::make('image')->image()->acceptedFileTypes(['image/*'])->required()
+                    FileUpload::make('image')->image()->acceptedFileTypes(['image/jpeg', 'image/png', 'image/gif', 'image/webp'])->required()
                         ->deleteUploadedFileUsing(fn($file) => Storage::disk('public')->delete($file))
                         ->directory('galleries')->uploadingMessage('Uploading...')->downloadable()->preserveFilenames()->openable(),
                     Textarea::make('description')->label('Description')->required()->rows(3),

--- a/app/Models/gallery.php
+++ b/app/Models/gallery.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
-use Illuminate\Support\Facades\Log; // na logovanie chýb
+use Illuminate\Support\Facades\Log;
 
 class Gallery extends Model
 {
@@ -26,53 +26,69 @@ class Gallery extends Model
     {
         static::saved(function ($gallery) {
             try {
+                // Spracovanie náhľadového obrázka
                 if ($gallery->image && Storage::disk('public')->exists($gallery->image)) {
-                    $imagePath = Storage::disk('public')->path($gallery->image);
-                    $resizedImagePath = Storage::disk('public')->path('resized_' . $gallery->image);
+                    self::resizeImage($gallery->image);
+                }
 
-                    // Otvorenie pôvodného obrázka pomocou GD
-                    $sourceImage = imagecreatefromstring(file_get_contents($imagePath));
-                    if ($sourceImage === false) {
-                        Log::error("Nepodarilo sa otvoriť obrázok: {$imagePath}");
-                        return; // Ukončí sa, ak nie je možné načítať obrázok
-                    }
-
-                    // Získanie pôvodných rozmerov
-                    $width = imagesx($sourceImage);
-                    $height = imagesy($sourceImage);
-
-                    // Výpočet nových rozmerov
-                    $newWidth = 800;
-                    $newHeight = 800;
-                    if ($width > $height) {
-                        $newHeight = (int)(($height / $width) * $newWidth);
-                    } else {
-                        $newWidth = (int)(($width / $height) * $newHeight);
-                    }
-
-                    // Vytvorenie nového obrázka s novými rozmermi
-                    $resizedImage = imagecreatetruecolor($newWidth, $newHeight);
-                    imagecopyresampled($resizedImage, $sourceImage, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
-
-                    // Uloženie zmenšeného obrázka vo formáte JPEG s kvalitou 90
-                    imagejpeg($resizedImage, $resizedImagePath, 90);
-
-                    // Nahradenie pôvodného obrázka novou verziou
-                    Storage::disk('public')->put($gallery->image, file_get_contents($resizedImagePath));
-
-                    // Uvoľnenie pamäte
-                    imagedestroy($sourceImage);
-                    imagedestroy($resizedImage);
-
-                    // Odstránenie dočasného súboru, ak existuje
-                    if (file_exists($resizedImagePath)) {
-                        unlink($resizedImagePath);
+                // Spracovanie obrázkov v galérii (v poli gallery_images)
+                if ($gallery->gallery_images) {
+                    $galleryImages = $gallery->gallery_images; // priame priradenie bez json_decode
+                    foreach ($galleryImages as $image) {
+                        if (Storage::disk('public')->exists($image)) {
+                            self::resizeImage($image);
+                        }
                     }
                 }
+
             } catch (\Exception $e) {
-                Log::error("Zlyhalo zmenšenie obrázka: " . $e->getMessage());
+                Log::error("Zlyhalo zmenšenie obrázkov v galérii: " . $e->getMessage());
             }
         });
+    }
+
+    // Funkcia na úpravu veľkosti obrázka
+    protected static function resizeImage($imagePath)
+    {
+        try {
+            // Cesta k obrázku
+            $fullImagePath = Storage::disk('public')->path($imagePath);
+
+            // Otvorenie pôvodného obrázka pomocou GD
+            $sourceImage = imagecreatefromstring(file_get_contents($fullImagePath));
+            if ($sourceImage === false) {
+                Log::error("Nepodarilo sa otvoriť obrázok: {$fullImagePath}");
+                return;
+            }
+
+            // Získanie pôvodných rozmerov
+            $width = imagesx($sourceImage);
+            $height = imagesy($sourceImage);
+
+            // Výpočet nových rozmerov so zachovaním pomeru strán
+            $newWidth = 800;
+            $newHeight = 800;
+            if ($width > $height) {
+                $newHeight = (int)(($height / $width) * $newWidth);
+            } else {
+                $newWidth = (int)(($width / $height) * $newHeight);
+            }
+
+            // Vytvorenie nového obrázka s novými rozmermi
+            $resizedImage = imagecreatetruecolor($newWidth, $newHeight);
+            imagecopyresampled($resizedImage, $sourceImage, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+
+            // Prepísanie pôvodného obrázka novou verziou so zmenšenými rozmermi
+            imagejpeg($resizedImage, $fullImagePath, 90);
+
+            // Uvoľnenie pamäte
+            imagedestroy($sourceImage);
+            imagedestroy($resizedImage);
+
+            Log::info("Obrázok bol úspešne zmenšený a uložený na pôvodné miesto: {$fullImagePath}");
+        } catch (\Exception $e) {
+            Log::error("Zlyhalo zmenšenie obrázka: " . $e->getMessage());
+        }
     }
 
     // Serializuje pole na JSON pred uložením do databázy

--- a/app/Models/gallery.php
+++ b/app/Models/gallery.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\Facades\Image;
+
 
 class Gallery extends Model
 {
@@ -30,4 +33,21 @@ class Gallery extends Model
         'gallery_images' => 'array',
         'is_published' => 'boolean',
     ];
+    protected static function booted()
+    {
+        static::saved(function ($gallery) {
+            // Skontrolujeme, či existuje nahratý obrázok
+            if ($gallery->image && Storage::disk('public')->exists($gallery->image)) {
+                // Načíta sa obrázok a zmení sa jeho veľkosť
+                $imagePath = Storage::disk('public')->path($gallery->image);
+                $resizedImage = Image::make($imagePath)->resize(800, 800, function ($constraint) {
+                    $constraint->aspectRatio();
+                    $constraint->upsize();
+                })->encode();
+
+                // Prepisujeme obrázok zmenšenou verziou
+                Storage::disk('public')->put($gallery->image, (string) $resizedImage);
+            }
+        });
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^3.2",
+        "intervention/image": "^3.9",
         "laravel/framework": "^11.9",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^2.9"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8b538a46fddf3c50a559f9a7c0edff5",
+    "content-hash": "c967dde3e244947f75354aec1595e609",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1961,6 +1961,150 @@
                 }
             ],
             "time": "2023-12-03T19:50:20+00:00"
+        },
+        {
+            "name": "intervention/gif",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/gif.git",
+                "reference": "42c131a31b93c440ad49061b599fa218f06f93be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/gif/zipball/42c131a31b93c440ad49061b599fa218f06f93be",
+                "reference": "42c131a31b93c440ad49061b599fa218f06f93be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1",
+                "phpunit/phpunit": "^10.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^3.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Gif\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "Native PHP GIF Encoder/Decoder",
+            "homepage": "https://github.com/intervention/gif",
+            "keywords": [
+                "animation",
+                "gd",
+                "gif",
+                "image"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/gif/issues",
+                "source": "https://github.com/Intervention/gif/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2024-09-20T13:35:02+00:00"
+        },
+        {
+            "name": "intervention/image",
+            "version": "3.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Intervention/image.git",
+                "reference": "b496d1f6b9f812f96166623358dfcafb8c3b1683"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/b496d1f6b9f812f96166623358dfcafb8c3b1683",
+                "reference": "b496d1f6b9f812f96166623358dfcafb8c3b1683",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "intervention/gif": "^4.2",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.6",
+                "phpstan/phpstan": "^1",
+                "phpunit/phpunit": "^10.0",
+                "slevomat/coding-standard": "~8.0",
+                "squizlabs/php_codesniffer": "^3.8"
+            },
+            "suggest": {
+                "ext-exif": "Recommended to be able to read EXIF data properly."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Intervention\\Image\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Oliver Vogel",
+                    "email": "oliver@intervention.io",
+                    "homepage": "https://intervention.io/"
+                }
+            ],
+            "description": "PHP image manipulation",
+            "homepage": "https://image.intervention.io/",
+            "keywords": [
+                "gd",
+                "image",
+                "imagick",
+                "resize",
+                "thumbnail",
+                "watermark"
+            ],
+            "support": {
+                "issues": "https://github.com/Intervention/image/issues",
+                "source": "https://github.com/Intervention/image/tree/3.9.1"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/interventionio",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/Intervention",
+                    "type": "github"
+                },
+                {
+                    "url": "https://ko-fi.com/interventionphp",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2024-10-27T10:15:54+00:00"
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",

--- a/config/app.php
+++ b/config/app.php
@@ -25,6 +25,8 @@ return [
     | services the application utilizes. Set this in your ".env" file.
     |
     */
+    
+
 
     'env' => env('APP_ENV', 'production'),
 
@@ -122,5 +124,47 @@ return [
         'driver' => env('APP_MAINTENANCE_DRIVER', 'file'),
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
+
+    'aliases' => [
+    'App' => Illuminate\Support\Facades\App::class,
+    'Arr' => Illuminate\Support\Arr::class,
+    'Auth' => Illuminate\Support\Facades\Auth::class,
+    'Blade' => Illuminate\Support\Facades\Blade::class,
+    'Broadcast' => Illuminate\Support\Facades\Broadcast::class,
+    'Bus' => Illuminate\Support\Facades\Bus::class,
+    'Cache' => Illuminate\Support\Facades\Cache::class,
+    'Config' => Illuminate\Support\Facades\Config::class,
+    'Cookie' => Illuminate\Support\Facades\Cookie::class,
+    'Crypt' => Illuminate\Support\Facades\Crypt::class,
+    'Date' => Illuminate\Support\Facades\Date::class,
+    'DB' => Illuminate\Support\Facades\DB::class,
+    'Eloquent' => Illuminate\Database\Eloquent\Model::class,
+    'Event' => Illuminate\Support\Facades\Event::class,
+    'File' => Illuminate\Support\Facades\File::class,
+    'Gate' => Illuminate\Support\Facades\Gate::class,
+    'Hash' => Illuminate\Support\Facades\Hash::class,
+    'Http' => Illuminate\Support\Facades\Http::class,
+    'Lang' => Illuminate\Support\Facades\Lang::class,
+    'Log' => Illuminate\Support\Facades\Log::class,
+    'Mail' => Illuminate\Support\Facades\Mail::class,
+    'Notification' => Illuminate\Support\Facades\Notification::class,
+    'Password' => Illuminate\Support\Facades\Password::class,
+    'Queue' => Illuminate\Support\Facades\Queue::class,
+    'Redirect' => Illuminate\Support\Facades\Redirect::class,
+    'Request' => Illuminate\Support\Facades\Request::class,
+    'Response' => Illuminate\Support\Facades\Response::class,
+    'Route' => Illuminate\Support\Facades\Route::class,
+    'Schema' => Illuminate\Support\Facades\Schema::class,
+    'Session' => Illuminate\Support\Facades\Session::class,
+    'Storage' => Illuminate\Support\Facades\Storage::class,
+    'Str' => Illuminate\Support\Str::class,
+    'URL' => Illuminate\Support\Facades\URL::class,
+    'Validator' => Illuminate\Support\Facades\Validator::class,
+    'View' => Illuminate\Support\Facades\View::class,
+
+    // Pridaj alias pre Intervention Image
+    //'Image' => Intervention\Image\Facades\Image::class,
+],
+
 
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -125,46 +125,7 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
-    'aliases' => [
-    'App' => Illuminate\Support\Facades\App::class,
-    'Arr' => Illuminate\Support\Arr::class,
-    'Auth' => Illuminate\Support\Facades\Auth::class,
-    'Blade' => Illuminate\Support\Facades\Blade::class,
-    'Broadcast' => Illuminate\Support\Facades\Broadcast::class,
-    'Bus' => Illuminate\Support\Facades\Bus::class,
-    'Cache' => Illuminate\Support\Facades\Cache::class,
-    'Config' => Illuminate\Support\Facades\Config::class,
-    'Cookie' => Illuminate\Support\Facades\Cookie::class,
-    'Crypt' => Illuminate\Support\Facades\Crypt::class,
-    'Date' => Illuminate\Support\Facades\Date::class,
-    'DB' => Illuminate\Support\Facades\DB::class,
-    'Eloquent' => Illuminate\Database\Eloquent\Model::class,
-    'Event' => Illuminate\Support\Facades\Event::class,
-    'File' => Illuminate\Support\Facades\File::class,
-    'Gate' => Illuminate\Support\Facades\Gate::class,
-    'Hash' => Illuminate\Support\Facades\Hash::class,
-    'Http' => Illuminate\Support\Facades\Http::class,
-    'Lang' => Illuminate\Support\Facades\Lang::class,
-    'Log' => Illuminate\Support\Facades\Log::class,
-    'Mail' => Illuminate\Support\Facades\Mail::class,
-    'Notification' => Illuminate\Support\Facades\Notification::class,
-    'Password' => Illuminate\Support\Facades\Password::class,
-    'Queue' => Illuminate\Support\Facades\Queue::class,
-    'Redirect' => Illuminate\Support\Facades\Redirect::class,
-    'Request' => Illuminate\Support\Facades\Request::class,
-    'Response' => Illuminate\Support\Facades\Response::class,
-    'Route' => Illuminate\Support\Facades\Route::class,
-    'Schema' => Illuminate\Support\Facades\Schema::class,
-    'Session' => Illuminate\Support\Facades\Session::class,
-    'Storage' => Illuminate\Support\Facades\Storage::class,
-    'Str' => Illuminate\Support\Str::class,
-    'URL' => Illuminate\Support\Facades\URL::class,
-    'Validator' => Illuminate\Support\Facades\Validator::class,
-    'View' => Illuminate\Support\Facades\View::class,
-
-    // Pridaj alias pre Intervention Image
-    //'Image' => Intervention\Image\Facades\Image::class,
-],
+    
 
 
 ];

--- a/database/migrations/2024_10_28_151027_modify_gallery_images_column_in_galleries_table.php
+++ b/database/migrations/2024_10_28_151027_modify_gallery_images_column_in_galleries_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyGalleryImagesColumnInGalleriesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('galleries', function (Blueprint $table) {
+            // Zmena typu stĺpca späť na TEXT
+            $table->text('gallery_images')->nullable()->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('galleries', function (Blueprint $table) {
+            // Návrat na pôvodný typ, ak bolo nastavené inak
+            $table->text('gallery_images')->nullable()->change();
+        });
+    }
+}
+
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,8 +4,6 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TeamController;
 use Illuminate\Support\Facades\Route;
-use Intervention\Image\ImageManagerStatic as Image;
-use Illuminate\Support\Facades\Storage;
 
 Route::get('/', [HomeController::class, 'home'])->name('home');
 Route::get('/contact', [HomeController::class, 'contact'])->name('contact');
@@ -19,22 +17,3 @@ Route::get('/profile', [ProfileController::class, 'index' ])->name('profile.inde
 
 Route::get('/gallery', [HomeController::class, 'gallery'])->name('gallery.index');
 Route::get('/gallery/{id}', [HomeController::class, 'galleryDetails'])->name('gallery.show');
-
-Route::get('/test-image', function () {
-    // Skontroluj, či súbor existuje, alebo použi konkrétnu cestu k obrázku
-    $imagePath = Storage::disk('public')->path('gallery_images/test.png');
-
-    if (!file_exists($imagePath)) {
-        return 'Image not found!';
-    }
-
-    // Skús zmenšiť a uložiť obrázok
-    $resizedImage = Image::make($imagePath)->resize(800, 800, function ($constraint) {
-        $constraint->aspectRatio();
-        $constraint->upsize();
-    })->encode();
-
-    Storage::disk('public')->put('gallery_images/test_resized.png', (string) $resizedImage);
-
-    return 'Image resized and saved as test_resized.png';
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,8 @@ use App\Http\Controllers\HomeController;
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\TeamController;
 use Illuminate\Support\Facades\Route;
+use Intervention\Image\ImageManagerStatic as Image;
+use Illuminate\Support\Facades\Storage;
 
 Route::get('/', [HomeController::class, 'home'])->name('home');
 Route::get('/contact', [HomeController::class, 'contact'])->name('contact');
@@ -17,3 +19,22 @@ Route::get('/profile', [ProfileController::class, 'index' ])->name('profile.inde
 
 Route::get('/gallery', [HomeController::class, 'gallery'])->name('gallery.index');
 Route::get('/gallery/{id}', [HomeController::class, 'galleryDetails'])->name('gallery.show');
+
+Route::get('/test-image', function () {
+    // Skontroluj, či súbor existuje, alebo použi konkrétnu cestu k obrázku
+    $imagePath = Storage::disk('public')->path('gallery_images/test.png');
+
+    if (!file_exists($imagePath)) {
+        return 'Image not found!';
+    }
+
+    // Skús zmenšiť a uložiť obrázok
+    $resizedImage = Image::make($imagePath)->resize(800, 800, function ($constraint) {
+        $constraint->aspectRatio();
+        $constraint->upsize();
+    })->encode();
+
+    Storage::disk('public')->put('gallery_images/test_resized.png', (string) $resizedImage);
+
+    return 'Image resized and saved as test_resized.png';
+});


### PR DESCRIPTION
This pull request introduces functionality to automatically resize all uploaded images to 300x300 pixels before saving them to the database.
The resizing occurs before the file path is stored, ensuring only one database entry per upload.
 
Ensure that the GD library is enabled in your PHP setup by uncommenting it in the php.ini file (extension=gd). This is required for image processing.